### PR TITLE
Next (#240)

### DIFF
--- a/calendar-service/src/main/scala/org/opentorah/calendar/service/Renderer.scala
+++ b/calendar-service/src/main/scala/org/opentorah/calendar/service/Renderer.scala
@@ -11,7 +11,7 @@ import org.opentorah.texts.rambam.{MishnehTorah, SeferHamitzvosLessons}
 import org.opentorah.texts.tanach.{Custom, Haftarah, Reading, Span, Torah}
 import org.opentorah.texts.tanach.Tanach.Psalms
 import org.opentorah.util.Collections
-import org.opentorah.xml.{PrettyPrinter, Xml}
+import org.opentorah.xml.{Html, PrettyPrinter, Xml}
 
 sealed abstract class Renderer(location: Location, spec: LanguageSpec) {
   protected val calendar: Calendar
@@ -41,17 +41,17 @@ sealed abstract class Renderer(location: Location, spec: LanguageSpec) {
 
   //  private def toLanguageString(what: LanguageString): String = what.toLanguageString(spec)
 
-  private def yearUrl(year: Calendar#YearBase, other: Boolean = false): String =
-    s"/${getName(other)}/${year.number}"
+  private def yearUrl(year: Calendar#YearBase, other: Boolean = false): Seq[String] =
+    Seq(getName(other), year.number.toString)
 
-  private def monthUrl(month: Calendar#MonthBase, other: Boolean = false): String =
-    s"/${getName(other)}/${month.year.number}/${month.numberInYear}"
+  private def monthUrl(month: Calendar#MonthBase, other: Boolean = false): Seq[String] =
+    Seq(getName(other), month.year.number.toString, month.numberInYear.toString)
 
-  private def monthNameUrl(month: Calendar#MonthBase, other: Boolean = false): String =
-    s"/${getName(other)}/${month.year.number}/${month.name.toLanguageString(spec)}"
+  private def monthNameUrl(month: Calendar#MonthBase, other: Boolean = false): Seq[String] =
+    Seq(getName(other), month.year.number.toString, month.name.toLanguageString(spec))
 
-  private def dayUrl(day: Calendar#DayBase, other: Boolean = false): String =
-    s"/${getName(other)}/${day.year.number}/${day.month.numberInYear}/${day.numberInMonth}"
+  private def dayUrl(day: Calendar#DayBase, other: Boolean = false): Seq[String] =
+    Seq(getName(other), day.year.number.toString, day.month.numberInYear.toString, day.numberInMonth.toString)
 
   private def yearLink(year: Calendar#YearBase, other: Boolean = false, text: Option[String] = None): Xml.Element =
     navLink(yearUrl(year, other = other), text.getOrElse(year.toLanguageString(spec)))
@@ -65,8 +65,8 @@ sealed abstract class Renderer(location: Location, spec: LanguageSpec) {
   private def dayLink(day: Calendar#DayBase, other: Boolean = false, text: Option[String] = None): Xml.Element =
     navLink(dayUrl(day, other = other), text.getOrElse(day.numberInMonthToLanguageString(spec)))
 
-  private def navLink(url: String, text: String): Xml.Element =
-    <a class="nav" href={s"$url$suffix"}>{text}</a>
+  private def navLink(url: Seq[String], text: String): Xml.Element =
+    Html.a(url).setQuery(suffix).addClass("nav")(text)
 
   private def suffix: String = Renderer.suffix(location, spec)
 
@@ -81,7 +81,7 @@ sealed abstract class Renderer(location: Location, spec: LanguageSpec) {
 
   def renderLanding: String = {
     val day: Calendar#DayBase = Calendars.now(calendar).day
-    renderHtml(s"/$name", dayLinks(day, other = false))
+    renderHtml(Seq(name), dayLinks(day, other = false))
   }
 
   def renderYear(yearStr: String): String = {
@@ -305,7 +305,7 @@ sealed abstract class Renderer(location: Location, spec: LanguageSpec) {
       </table>
     }
 
-  private def renderHtml(url: String, content: Xml.Element): String =
+  private def renderHtml(url: Seq[String], content: Xml.Element): String =
     Renderer.renderHtml(url, content, location, spec)
 }
 
@@ -435,18 +435,18 @@ object Renderer {
   }
 
   def renderRoot(location: Location, spec: LanguageSpec): String = renderHtml(
-    url = "/",
+    url = Seq.empty,
     content =
       <div>
-        <div><a href={s"/$jewishRendererName"}>jewish</a></div>,
-        <div><a href={s"/$gregorianRenderername"}>gregorian</a></div>
+        <div>{Html.a(Seq(jewishRendererName))(text = "jewish")}</div>,
+        <div>{Html.a(Seq(gregorianRenderername))(text = "gregorian")}</div>
       </div>,
     location = location,
     spec = spec
   )
 
   def renderHtml(
-    url: String,
+    url: Seq[String],
     content: Xml.Element,
     location: Location,
     spec: LanguageSpec
@@ -454,12 +454,12 @@ object Renderer {
     val languages: Seq[Xml.Element] = Language.values.map(_.toSpec) map { spec1 =>
       val languageName = spec1.languageName
       if (spec1.language == spec.language) <span class="picker">{languageName}</span>
-      else <a class="picker" href={s"$url${suffix(location, spec1)}"}>{languageName}</a>
+      else Html.a(url).setQuery(suffix(location, spec1)).addClass("picker")(text = languageName)
     }
 
     val locations: Seq[Xml.Element] = Seq(Location.HolyLand, Location.Diaspora).map { location1 =>
       if (location1 == location) <span class="picker">{location1.name}</span>
-      else <a class="picker" href={s"$url${suffix(location1, spec)}"}>{location1.name}</a>
+      else Html.a(url).setQuery(suffix(location1, spec)).addClass("picker")(text = location1.name)
     }
 
     //        title("Reading Schedule")?
@@ -482,5 +482,5 @@ object Renderer {
     if (spec.language.contains(Language.Hebrew)) "rtl" else "ltr"
 
   private def suffix(location: Location, spec: LanguageSpec): String =
-    s"?inHolyLand=${location.inHolyLand}&lang=${spec.languageName}"
+    s"inHolyLand=${location.inHolyLand}&lang=${spec.languageName}"
 }

--- a/collector/CHANGELOG.md
+++ b/collector/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 - site is now dynamic!
+- moved Markdown code into a separate package;
+- double-escape XML tag start characters and such in Markdown code blocks;
+- PrettyPrinter supports preformatted elements;
+- and doesn't let Paiges to mis-indent them;
 
 ## [0.2.3] - 2021-02-02
 - serve using local Docker

--- a/collector/src/main/resources/org/opentorah/collector/Selector.xml
+++ b/collector/src/main/resources/org/opentorah/collector/Selector.xml
@@ -63,6 +63,7 @@
   <selector>
     <name n="facsimile" lang="en"/>
     <name n="факсимиле" lang="ru"/>
+    <name n="facs" lang="en"/>
   </selector>
   <selector>
     <name n="tei" lang="en"/>

--- a/collector/src/main/scala/org/opentorah/collector/Collection.scala
+++ b/collector/src/main/scala/org/opentorah/collector/Collection.scala
@@ -80,8 +80,9 @@ final class Collection(
 
       Collection.Column("Страницы", "pages", { document: Document =>
         val text: Document.TextFacet = textFacet.of(document)
-        for (page <- document.pages(pageType)) yield page.pb.addAttributes(
-          text.a(site, part = Some(Pb.pageId(page.pb.n)))(text = page.displayName)
+        Xml.multi(separator = " ", nodes =
+          for (page <- document.pages(pageType))
+            yield page.pb.addAttributes(text.a(site).setFragment(Pb.pageId(page.pb.n))(text = page.displayName))
         )
       }),
 

--- a/collector/src/main/scala/org/opentorah/collector/Document.scala
+++ b/collector/src/main/scala/org/opentorah/collector/Document.scala
@@ -107,7 +107,7 @@ object Document extends Element[Document]("document") with Directory.EntryMaker[
           for (page: Page <- document.pages(collection.pageType).filterNot(_.pb.isMissing)) yield {
             val n: String = page.pb.n
             val pageId: String = Pb.pageId(n)
-            text.a(site, part = Some(pageId))(
+            text.a(site).setFragment(pageId)(
               <figure>
                 <img
                 id={pageId}

--- a/collector/src/main/scala/org/opentorah/collector/Entity.scala
+++ b/collector/src/main/scala/org/opentorah/collector/Entity.scala
@@ -48,7 +48,8 @@ final class Entity(
         </l>
         }
         {for ((collection, texts) <- byCollection) yield
-        <l>{collection.pathHeaderHorizontal(site)}: {for (text <- texts) yield text.a(site)(text = text.document.baseName)}</l>}
+        <l>{collection.pathHeaderHorizontal(site)}:
+          {Xml.multi(separator = " ", nodes = for (text <- texts) yield text.a(site)(text = text.document.baseName))}</l>}
       </p>
 
     val entity: TeiEntity = teiEntity(site)

--- a/collector/src/main/scala/org/opentorah/collector/EntityLists.scala
+++ b/collector/src/main/scala/org/opentorah/collector/EntityLists.scala
@@ -33,7 +33,7 @@ final class EntityLists(
 
     <div>
       <p>
-        {for (list <- nonEmptyLists) yield <l>{a(site, part = Some(list.names.name))(xml = list.title)}</l>}
+        {for (list <- nonEmptyLists) yield <l>{a(site).setFragment(list.names.name)(xml = list.title)}</l>}
       </p>
       {for (list <- nonEmptyLists) yield
       <list id={list.names.name}>

--- a/collector/src/main/scala/org/opentorah/collector/HtmlContent.scala
+++ b/collector/src/main/scala/org/opentorah/collector/HtmlContent.scala
@@ -8,7 +8,7 @@ trait HtmlContent {
   def htmlHeadTitle: Option[String]
   def htmlBodyTitle: Option[Xml.Nodes] = None
 
-  final def a(site: Site, part: Option[String] = None): Html.a = site.a(path(site), part)
+  final def a(site: Site): Html.a = site.a(path(site))
 
   def path           (site: Site): Store.Path
   def navigationLinks(site: Site): Seq[Xml.Element] = Seq.empty

--- a/collector/src/main/scala/org/opentorah/collector/Note.scala
+++ b/collector/src/main/scala/org/opentorah/collector/Note.scala
@@ -1,5 +1,6 @@
 package org.opentorah.collector
 
+import org.opentorah.markdown.Markdown
 import org.opentorah.xml.{Attribute, Element, Parsable, Parser, Unparser, Xml}
 
 final class Note(
@@ -10,7 +11,7 @@ final class Note(
   override def htmlHeadTitle: Option[String] = title
   override def htmlBodyTitle: Option[Xml.Nodes] = htmlHeadTitle.map(Xml.mkText)
   override def path(site: Site): Store.Path = Seq(site.notes, this)
-  override def content(site: Site): Xml.Element = site.notes.getFile(this).html
+  override def content(site: Site): Xml.Element = site.notes.getFile(this).content
 }
 
 object Note extends Element[Note]("note") with Directory.EntryMaker[Markdown, Note] {

--- a/collector/src/main/scala/org/opentorah/collector/Notes.scala
+++ b/collector/src/main/scala/org/opentorah/collector/Notes.scala
@@ -1,5 +1,6 @@
 package org.opentorah.collector
 
+import org.opentorah.markdown.Markdown
 import org.opentorah.xml.{Element, FromUrl, Parsable, Parser, Unparser, Xml}
 import java.net.URL
 
@@ -14,7 +15,7 @@ final class Notes(
   new Notes.All(_),
 ) with By with HtmlContent {
 
-  override protected def loadFile(url: URL): Markdown = Markdown.load(url)
+  override protected def loadFile(url: URL): Markdown = Markdown(url)
 
   override def findByName(name: String): Option[Store] =
     Store.findByName(name, "html", getDirectory.findByName)

--- a/collector/src/main/scala/org/opentorah/collector/Report.scala
+++ b/collector/src/main/scala/org/opentorah/collector/Report.scala
@@ -4,6 +4,7 @@ import org.opentorah.metadata.Names
 import org.opentorah.tei.{EntityReference, Unclear}
 import org.opentorah.util.Files
 import org.opentorah.xml.{Html, Xml}
+import java.net.URI
 
 abstract class Report[T](val name: String, val title: String) extends Store with HtmlContent {
   final override def names: Names = Names(name)
@@ -28,11 +29,11 @@ object Report {
   ) {
     override protected def lines(site: Site): Seq[WithSource[EntityReference]] =  site.getReferences
       .filter(_.value.ref.isEmpty)
-      .sortBy(reference => Xml.text(reference.value.name).toLowerCase)
+      .sortBy(reference => Xml.toString(reference.value.name).toLowerCase)
 
     override protected def lineToXml(reference: WithSource[EntityReference], site: Site): Xml.Element = {
       val source: String = reference.source
-      <l>{Xml.text(reference.value.name)} в {Html.a(path = Files.splitUrl(source))(text = source)}</l>
+      <l>{Xml.toString(reference.value.name)} в {Html.a(new URI(source))(text = source)}</l>
     }
   }
 
@@ -45,7 +46,7 @@ object Report {
 
     override protected def lineToXml(unclear: WithSource[Unclear.Value], site: Site): Xml.Element = {
       val source: String = unclear.source
-      <l>{Xml.text(unclear.value.xml)} в {Html.a(path = Files.splitUrl(source))(text = source)}</l>
+      <l>{Xml.toString(unclear.value.xml)} в {Html.a(new URI(source))(text = source)}</l>
     }
   }
 

--- a/collector/src/main/scala/org/opentorah/markdown/DoubleEscapeHtmlNodeRenderer.scala
+++ b/collector/src/main/scala/org/opentorah/markdown/DoubleEscapeHtmlNodeRenderer.scala
@@ -1,0 +1,112 @@
+package org.opentorah.markdown
+
+import com.vladsch.flexmark.ast.{Code, CodeBlock, FencedCodeBlock, IndentedCodeBlock, Text}
+import com.vladsch.flexmark.html.{HtmlRendererOptions, HtmlWriter}
+import com.vladsch.flexmark.html.renderer.{CoreNodeRenderer, NodeRenderer, NodeRendererContext, NodeRendererFactory,
+  NodeRenderingHandler}
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.html.Escaping
+import com.vladsch.flexmark.util.options.DataHolder
+import com.vladsch.flexmark.util.sequence.BasedSequence
+import org.opentorah.markdown.DoubleEscapeHtmlNodeRenderer.doubleEscape
+import scala.jdk.CollectionConverters._
+
+object DoubleEscapeHtmlNodeRenderer {
+  // Note: FlexMark HtmlRenderer escapes the tags, but when I re-parse its output into XML,
+  // XML parser un-escapes them, so I force double-escaping by pre-escaping the fenced code block.
+  // I am not sure why doesn't everybody need it: aren't browser's parsers supposed to un-escape default entities?
+  // In order to be able to substitute this call for the html.text(string) that CoreNodeRenderer has,
+  // I had to duplicate a *lot* of code from there. There must be a better way!
+  private def doubleEscape(string: String, html: HtmlWriter): Unit = {
+    // html.text() calls Escaping; I pre-escape once more here:
+    html.text(Escaping.escapeHtml(string, false))
+  }
+
+  final class Factory extends NodeRendererFactory {
+    override def create(options: DataHolder): NodeRenderer = {
+      new DoubleEscapeHtmlNodeRenderer(options)
+    }
+  }
+}
+
+final class DoubleEscapeHtmlNodeRenderer(options: DataHolder) extends NodeRenderer {
+  private val codeContentBlock: Boolean = Parser.FENCED_CODE_CONTENT_BLOCK.getFrom(options)
+  private val codeSoftLineBreaks: Boolean = Parser.CODE_SOFT_LINE_BREAKS.getFrom(options)
+
+  override def getNodeRenderingHandlers: java.util.Set[NodeRenderingHandler[_]] = Set[NodeRenderingHandler[_]](
+    new NodeRenderingHandler[FencedCodeBlock](classOf[FencedCodeBlock], DoubleEscapeHtmlNodeRenderer.this.render),
+    new NodeRenderingHandler[IndentedCodeBlock](classOf[IndentedCodeBlock], DoubleEscapeHtmlNodeRenderer.this.render),
+    new NodeRenderingHandler[CodeBlock](classOf[CodeBlock], DoubleEscapeHtmlNodeRenderer.this.render),
+    new NodeRenderingHandler[Code](classOf[Code], DoubleEscapeHtmlNodeRenderer.this.render)
+  ).asJava
+
+  private def render(node: FencedCodeBlock, context: NodeRendererContext, html: HtmlWriter): Unit = {
+    html.line
+    html.srcPosWithTrailingEOL(node.getChars).withAttr().tag("pre").openPre
+
+    val info: BasedSequence = node.getInfo
+    if (info.isNotNull && !info.isBlank) {
+      val language: BasedSequence = node.getInfoDelimitedByAny(" ")
+      html.attr("class", context.getHtmlOptions.languageClassPrefix + language.unescape())
+    } else {
+      val noLanguageClass: String = context.getHtmlOptions.noLanguageClass.trim
+      if (noLanguageClass.nonEmpty) html.attr("class", noLanguageClass)
+    }
+
+    html.srcPosWithEOL(node.getContentChars()).withAttr(CoreNodeRenderer.CODE_CONTENT).tag("code")
+    if (codeContentBlock) context.renderChildren(node)
+    else doubleEscape(node.getContentChars.normalizeEOL, html)
+
+    html.tag("/code")
+    html.tag("/pre").closePre
+    html.lineIf(context.getHtmlOptions.htmlBlockCloseTagEol)
+  }
+
+  private def render(node: IndentedCodeBlock, context: NodeRendererContext, html: HtmlWriter): Unit = {
+    html.line()
+    html.srcPosWithEOL(node.getChars).withAttr.tag("pre").openPre
+
+    val noLanguageClass: String = context.getHtmlOptions.noLanguageClass.trim
+    if (noLanguageClass.nonEmpty) html.attr("class", noLanguageClass)
+
+    html.srcPosWithEOL(node.getContentChars).withAttr(CoreNodeRenderer.CODE_CONTENT).tag("code")
+    if (codeContentBlock) context.renderChildren(node)
+    else doubleEscape(node.getContentChars.trimTailBlankLines.normalizeEndWithEOL, html)
+
+    html.tag("/code")
+    html.tag("/pre").closePre()
+    html.lineIf(context.getHtmlOptions.htmlBlockCloseTagEol)
+  }
+
+  private def render(node: CodeBlock, context: NodeRendererContext, html: HtmlWriter): Unit = doubleEscape(
+    if (node.getParent.isInstanceOf[IndentedCodeBlock]) node.getContentChars.trimTailBlankLines.normalizeEndWithEOL
+    else node.getContentChars.normalizeEOL,
+    html
+  )
+
+  private def render(node: Code, context: NodeRendererContext, html: HtmlWriter): Unit = {
+    val htmlOptions: HtmlRendererOptions = context.getHtmlOptions
+    if (htmlOptions.codeStyleHtmlOpen == null || htmlOptions.codeStyleHtmlClose == null) {
+      if (context.getHtmlOptions.sourcePositionParagraphLines) html.withAttr().tag("code")
+      else html.srcPos(node.getText).withAttr().tag("code")
+
+      if (codeSoftLineBreaks && !htmlOptions.isSoftBreakAllSpaces) {
+        for (child <- node.getChildren.asScala) {
+          if (child.isInstanceOf[Text]) doubleEscape(Escaping.collapseWhitespace(child.getChars, true), html)
+          else context.render(child)
+        }
+      } else doubleEscape(Escaping.collapseWhitespace(node.getText, true), html)
+      html.tag("/code")
+    } else {
+      html.raw(htmlOptions.codeStyleHtmlOpen)
+      if (codeSoftLineBreaks && !htmlOptions.isSoftBreakAllSpaces) {
+        for (child <- node.getChildren.asScala) {
+          if (child.isInstanceOf[Text]) doubleEscape(Escaping.collapseWhitespace(child.getChars, true), html)
+          else context.render(child)
+        }
+      } else doubleEscape(Escaping.collapseWhitespace(node.getText, true), html)
+      html.raw(htmlOptions.codeStyleHtmlClose)
+    }
+  }
+}
+

--- a/collector/src/main/scala/org/opentorah/markdown/DoubleEscapeHtmlRendererExtension.scala
+++ b/collector/src/main/scala/org/opentorah/markdown/DoubleEscapeHtmlRendererExtension.scala
@@ -1,0 +1,19 @@
+package org.opentorah.markdown
+
+import com.vladsch.flexmark.Extension
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.util.options.MutableDataHolder
+
+final class DoubleEscapeHtmlRendererExtension extends HtmlRenderer.HtmlRendererExtension {
+  override def rendererOptions(options: MutableDataHolder): Unit = {}
+
+  override def extend(rendererBuilder: HtmlRenderer.Builder, rendererType: String): Unit = {
+    if (rendererBuilder.isRendererType("HTML")) {
+      rendererBuilder.nodeRendererFactory(new DoubleEscapeHtmlNodeRenderer.Factory())
+    }
+  }
+}
+
+object DoubleEscapeHtmlRendererExtension {
+  def create: Extension = new DoubleEscapeHtmlRendererExtension
+}

--- a/docbook/src/test/scala/org/opentorah/docbook/PluginTest.scala
+++ b/docbook/src/test/scala/org/opentorah/docbook/PluginTest.scala
@@ -36,8 +36,11 @@ class PluginTest extends AnyFlatSpecLike with Matchers {
     PrettyPrinter.default.render(<e a="http://&version;"/>) shouldBe """<e a="http://&version;"/>""" + "\n"
 
     // If the attribute value is enclosed in {}, making it dynamic, IntelliJ does not complain any longer -
-    // but Scala XML encodes the entity reference, so nothing works:
-    PrettyPrinter.default.render(<e a={"http://&version;"}/>) shouldBe """<e a="http://&amp;version;"/>""" + "\n"
+    // but Scala XML encodes the entity reference, so nothing works...
+    // UPDATE 2021-02-15: things started working all of a sudden;
+    // tzorich iyun if this is connected to the recent changes in the PrettyPrinter (handling preformatted elements)
+    // or Markdown (double-escaping dangerous symbols), although I don't see how can it be...
+    PrettyPrinter.default.render(<e a={"http://&version;"}/>) shouldBe """<e a="http://&version;"/>""" + "\n"
 
     // In the tests below, I am thus forced to forego the {} - and suffer redness from IntelliJ...
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ zincVersion        = 1.4.0-M5
 # XML #
 scalaXmlVersion    = 2.0.0-M4
 #tagsoupVersion     = 1.2.1
-paigesVersion      = 0.3.2
+paigesVersion      = 0.4.0
 
 xercesVersion      = 2.12.1
 xmlApisVersion     = 1.4.01

--- a/tei/src/main/scala/org/opentorah/tei/Tei.scala
+++ b/tei/src/main/scala/org/opentorah/tei/Tei.scala
@@ -1,8 +1,9 @@
 package org.opentorah.tei
 
 import org.opentorah.util.Files
-import org.opentorah.xml.{Attribute, Dialect, Element, From, Html, Namespace, Parsable, Parser, PrettyPrinter, Unparser, Xml}
+import org.opentorah.xml.{Attribute, Dialect, Element, Html, Namespace, Parsable, Parser, PrettyPrinter, Unparser, Xml}
 import zio.{URIO, ZIO}
+import java.net.URI
 
 final case class Tei(
   teiHeader: TeiHeader,
@@ -67,7 +68,7 @@ object Tei extends Element[Tei]("TEI") with Dialect with Html.To {
           ZIO.succeed(Html.a()(children))
         else
           ZIO.access[Html.State](_.resolver.findByRef(ref.get)).map(_.
-            getOrElse(Html.a(path = ref.toSeq))
+            getOrElse(Html.a(ref.toSeq))
             (children)
           )
 
@@ -84,7 +85,7 @@ object Tei extends Element[Tei]("TEI") with Dialect with Html.To {
         require(Xml.isEmpty(children), element)
         val pageId: String = Pb.pageId(Pb.nAttribute.get(element))
         ZIO.access[Html.State](_.resolver.facs(pageId)).map(_
-          .getOrElse(Html.a(path = Seq(pageId)))
+          .getOrElse(Html.a(Seq(pageId)))
           .copy(id = Some(pageId))
           (text = facsimileSymbol)
         )
@@ -114,15 +115,13 @@ object Tei extends Element[Tei]("TEI") with Dialect with Html.To {
   }
 
   private def reference(element: Xml.Element): URIO[Html.State, Html.a] = {
-    val href: String = targetAttribute.get(element)
+    val uri: URI = new URI(targetAttribute.get(element))
 
     // TODO maybe just call up regardless?
-    if (!href.startsWith("/")) ZIO.succeed(Html.a(path = Seq(href), pathIsAbsolute = true)) else {
-      val (url: String, part: Option[String]) = Files.urlAndPart(href)
-
-      ZIO.access[Html.State](_.resolver.resolve(Files.splitUrl(url))).map(_
-        .getOrElse(Html.a(path = Seq(href)))
-        .copy(part = part)
+    if (uri.isAbsolute) ZIO.succeed(Html.a(uri)) else {
+      ZIO.access[Html.State](_.resolver.resolve(Files.splitUrl(uri.getPath))).map(_
+        .map(a => Option(uri.getFragment).fold(a)(a.setFragment))
+        .getOrElse(Html.a(uri))
       )
     }
   }

--- a/tei/src/test/resources/org/opentorah/tei/905.xml
+++ b/tei/src/test/resources/org/opentorah/tei/905.xml
@@ -5,7 +5,7 @@
     <fileDesc>
       <titleStmt><editor role="transcriber"><persName ref="ALD">Арье-Лейб Дубинский</persName></editor></titleStmt>
       <publicationStmt>
-        <publisher><ptr target="www.alter-rebbe.org"/></publisher>
+        <publisher><ptr target="http://www.alter-rebbe.org"/></publisher>
         <availability status="free"><licence><ab><ref n="license" target="http://creativecommons.org/licenses/by/4.0/">
           Creative Commons Attribution 4.0 International License</ref></ab></licence></availability>
       </publicationStmt>

--- a/tei/src/test/scala/org/opentorah/tei/TeiTest.scala
+++ b/tei/src/test/scala/org/opentorah/tei/TeiTest.scala
@@ -25,11 +25,10 @@ final class TeiTest extends AnyFlatSpec with Matchers {
     val resolver = new LinkResolver {
       override def resolve(url: Seq[String]): Option[Html.a] = None
       override def findByRef(ref:  String): Option[Html.a] = None
-      override def facs(pageId: String): Option[Html.a] = Some(Html.a(
-        path = Seq("facsimiles"),
-        part = Some(pageId),
-        target = Some("facsViewer")
-      ))
+      override def facs(pageId: String): Option[Html.a] = Some(Html.a(Seq("facsimiles"))
+        .setFragment(pageId)
+        .setTarget("facsViewer")
+      )
     }
 
     Tei.toHtml(resolver, element)

--- a/util/src/main/scala/org/opentorah/util/Files.scala
+++ b/util/src/main/scala/org/opentorah/util/Files.scala
@@ -79,14 +79,6 @@ object Files {
   def isFileUrl(url: URL): Boolean = url.getProtocol == "file"
   def isJarUrl(url: URL): Boolean = url.getProtocol == "jar"
 
-  def urlAndPart(what: String): (String, Option[String]) = Strings.split(what, '#')
-
-  def fileName(url: URL): String = Files.nameAndExtension(Files.pathAndName(url.getPath)._2)._1
-
-  def addPart(url: Seq[String], part: Option[String]): Seq[String] = part.fold(url)(addPart(url, _))
-  def addPart(url: Seq[String], part: String): Seq[String] = add(url, "#" + part)
-  def addExtension(url: Seq[String], extension: String): Seq[String] =  add(url, "." + extension)
-
   def add(url: Seq[String], what: String): Seq[String] =
     url.init :+ (url.last + what)
 

--- a/xml/src/main/scala/org/opentorah/xml/Current.scala
+++ b/xml/src/main/scala/org/opentorah/xml/Current.scala
@@ -10,6 +10,7 @@ private[xml] final case class Current(
 ) {
   def takeAttribute(attribute: Attribute[_]): Current.Next[Option[String]] =
     IO.succeed((
+      // TODO maybe take namespace into account?
       copy(attributes = attributes.filterNot(candidate => attribute == candidate.attribute)),
       // TODO handle repeated attributes?
       attributes.find(candidate => attribute == candidate.attribute).flatMap(_.value)

--- a/xml/src/main/scala/org/opentorah/xml/Dom.scala
+++ b/xml/src/main/scala/org/opentorah/xml/Dom.scala
@@ -92,8 +92,7 @@ object Dom extends Model {
     element
   }
 
-  // TODO implement
-  override def setAttributes(attributes: Seq[Attribute.Value[_]], element: Element): Element = ???
+  override def setAttributes(attributes: Seq[Attribute.Value[_]], element: Element): Element = ??? // TODO implement
 
   override def getChildren(element: Element): Nodes = {
     val list: NodeList = element.getChildNodes

--- a/xml/src/main/scala/org/opentorah/xml/Model.scala
+++ b/xml/src/main/scala/org/opentorah/xml/Model.scala
@@ -19,7 +19,7 @@ trait Model extends PreModel {
   final def isCharacters(node: Node): Boolean = isText(node) && getText(asText(node)).trim.nonEmpty
 
   def toString(node: Node): String
-  final def toString(nodes: Nodes): String = nodes.map(toString).mkString("")
+  final def toString(nodes: Nodes): String = nodes.map(toString).mkString(" ")
 
   def isElement(node: Node): Boolean
   def asElement(node: Node): Element

--- a/xml/src/main/scala/org/opentorah/xml/PreModel.scala
+++ b/xml/src/main/scala/org/opentorah/xml/PreModel.scala
@@ -13,7 +13,6 @@ trait PreModel {
   def isNamespaceDeclared(namespace: Namespace, element:  PreElement): Boolean
   def declareNamespace(namespace: Namespace, element: Element): Element
 
-  // TODO return Attribute.Value?
   final def getAttribute[T](attribute: Attribute[T], element: PreElement): Option[T] =
     attribute.get(getAttributeValueString(attribute, element))
 

--- a/xml/src/main/scala/org/opentorah/xml/Sax.scala
+++ b/xml/src/main/scala/org/opentorah/xml/Sax.scala
@@ -105,8 +105,7 @@ object Sax extends PreModel {
     attributes
   }
 
-  // TODO implement
-  override def setAttributes(attributes: Seq[Attribute.Value[_]], element: Element): Element = ???
+  override def setAttributes(attributes: Seq[Attribute.Value[_]], element: Element): Element = ??? // TODO implement
 
   // Note: XMLObj.setAttributes() sets namespace on an attribute only if it already saw
   // the declarations of that namespace, so I am making sure that they are there (and in the beginning);

--- a/xml/src/main/scala/org/opentorah/xml/Xml.scala
+++ b/xml/src/main/scala/org/opentorah/xml/Xml.scala
@@ -1,7 +1,7 @@
 package org.opentorah.xml
 
 import org.opentorah.util.Strings
-import zio.{Runtime, URIO, ZIO}
+import zio.{URIO, ZIO}
 import scala.xml.{MetaData, NamespaceBinding, Null, SpecialNode, TopScope}
 
 object Xml extends Model {
@@ -42,20 +42,18 @@ object Xml extends Model {
     Parser.unsafeRun(result.provide(state))
   }
 
-  def descendants[T](node: Node, elementName: String, elements: Elements[T]): Seq[T] =
-    node.flatMap(_ \\ elementName).filter(isElement).map[Element](asElement)
+  def descendants[T](node: Node, elementName: String, elements: Elements[T]): Seq[T] = node
+    .flatMap(_ \\ elementName).filter(isElement).map[Element](asElement)
     .map(descendant => Parser.parseDo(elements.parse(From.xml("descendants", descendant))))
 
   def multi(nodes: Nodes, separator: String = ", "): Nodes = nodes match {
     case Nil => Nil
     case n :: Nil => Seq(n)
-    case n :: n1 :: ns if n.isInstanceOf[Element] && n1.isInstanceOf[Element] => Seq(n, mkText(separator)) ++ multi(n1 :: ns)
-    case n :: ns => Seq(n) ++ multi(ns)
+    case n :: n1 :: ns if n.isInstanceOf[Element] && n1.isInstanceOf[Element] =>
+      Seq(n, mkText(separator)) ++ multi(n1 :: ns, separator)
+    case n :: ns => Seq(n) ++ multi(ns, separator)
     case n => n
   }
-
-  // TODO merge with Model.toString(Nodes)
-  def text(nodes: Nodes): String = nodes.map(_.text.trim).mkString(" ")
 
   override def toString(node: Node): String = Strings.squashWhitespace {
     node match {
@@ -84,6 +82,7 @@ object Xml extends Model {
     uri = element.getNamespace(element.prefix)
   )
 
+  // Note: maybe support re-definitions of the namespace bindings - like in  scala.xml.NamespaceBinding.shadowRedefined()?
   override def getNamespaces(element: Element): Seq[Namespace] = {
     @scala.annotation.tailrec
     def get(result: Seq[Namespace], namespaceBinding: NamespaceBinding): Seq[Namespace] =
@@ -122,14 +121,8 @@ object Xml extends Model {
       Attribute(
         name = attribute.key,
         namespace = namespace
-        // TODO Note: in Scala 2.13, Seq is in scala.collection.immutable, but Scala XML still returns scala.collection.Seq -
-        // hence the `value =>...`
-      ).optional.withValue(Option(attribute.value).map(value => getAttributeValueText(value)))
+      ).optional.withValue(Option(attribute.value).map(_.text))
     }
-
-  // TODO WTF?
-  private def getAttributeValueText(value: Nodes): String =
-    Strings.sbToString(scala.xml.Utility.sequenceToXML(value, TopScope, _, stripComments = true))
 
   // TODO addAll() doesn't modify existing attributes; this should...
   override protected def setAttribute[T](attribute: Attribute[T], value: T, element: Element): Element =

--- a/xml/src/test/scala/org/opentorah/xml/PrettyPrinterTest.scala
+++ b/xml/src/test/scala/org/opentorah/xml/PrettyPrinterTest.scala
@@ -109,6 +109,14 @@ final class PrettyPrinterTest extends AnyFlatSpec with Matchers {
          |"2020-02-24"
          |/>blah</creation>""")
 
+    check(<p><l>line1</l>
+      <!-- comment --><l>line2</l></p>, 30, expected =
+      """|<p>
+         |  <l>line1</l>
+         |  <!-- comment -->
+         |  <l>line2</l>
+         |</p>""")
+
     check(
       <xsl:stylesheet xmlns:xsl={Xsl.namespace.uri} version={Xsl.version(false)}
                       xmlns:db="http://docbook.org/ns/docbook"


### PR DESCRIPTION
* - clinginess of links: work in progress:)

* - clingy <a>s;

* - Html.a cleanup;

* - Html.a cleanup;

* - Xml.toString() cleanup;

* - moved Markdown code into a separate package;
- double-escape XML tag start characters and such in Markdown code blocks;
- PrettyPrinter supports preformatted elements;
- and doesn't let Paiges to mis-indent them;

* - cleanup;