### PR TITLE
0.10.16

### DIFF
--- a/.github/workflows/BranchCI.yaml
+++ b/.github/workflows/BranchCI.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: "Set up Java"
         uses: actions/setup-java@master
         with:
-          java-version: 11
+          java-version: '21'
           distribution: 'zulu'
 
       - name: "Build and test"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: "Set up Java"
         uses: actions/setup-java@master
         with:
-          java-version: 11
+          java-version: '21'
           distribution: 'zulu'
 
 #  disabled while working on fast-changing Markdown files...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.16] - 2025-01-17
+- cleanup: remove more mentions of DocBook
+- fix: eliminated invalid call to Project.afterEvaluate() in TaskWithNode
+- chore: Java 21
+- chore: removed calls to deprecated URL constructors
+- chore: Scala 3.6.3/2.13.16
+- chore: Gradle cleanup
+
 ## [0.10.15] - 2025-01-11
 - cleanup: util: build, node
 - fix: eliminated calls to Task.getProject() during task execution

--- a/README.md
+++ b/README.md
@@ -94,17 +94,12 @@ Historically, thematically cohesive packages were relegated to separate Gradle m
 separate repositories. This approach helps enforce layered architecture: no imports of the higher layer types in the
 lower layers. It also helps to trim down unneeded dependencies when using specific subset of the functionality.
 
-Since I am just about the only user of the code, the latter reason is not compelling: nobody is using just the FOP
-functionality, and it doesn't really matter if the DocBook plugin drags in the Jewish calendar code that it
-does not use, since it is not deployed in any resources-constrained service.
+Since I am just about the only user of the code, the latter reason is not compelling.
 
 The first reason is not that compelling either: Gradle doesn't block cyclical inter-module dependencies completely.
 Besides, relying on Gradle in this respect means putting every cohesive package in a separate module, which seems excessive.
 
 As a result, I currently use the fewest number of modules approach: code is separated in a module only if it needs
-to be deployed separately, as a website (docs), a plugin (docbook), or a service (collector, texts).
-
-If it turns out that the amount of DocBook-related code that gets moved into the core module and ends up being
-included in the services I run is problematic, I'll think about splitting it out.
+to be deployed separately, as a website (docs), or a service (collector, texts).
 
 If users that need just the calendar code appear, I'll think about splitting that ;)

--- a/configure.gradle
+++ b/configure.gradle
@@ -1,4 +1,4 @@
-project.version = '0.10.15'
+project.version = '0.10.16'
 project.group = 'org.opentorah'
 
 dependencies {
@@ -18,8 +18,7 @@ dependencies {
 
 // Note: starting with Gradle 8.0, without explicit toolchain specification, Java 8 gets picked up
 // even when Gradle itself runs on Java 11?!
-// TODO it seems that this causes `bad option '-target:11' was ignored` from the Scala compiler though...
-java.toolchain.languageVersion = JavaLanguageVersion.of(11)
+java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
 tasks.withType(ScalaCompile).configureEach {
   scalaCompileOptions.with {

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,12 +8,12 @@ pluginManagement {
     id 'com.github.ben-manes.versions' version '0.44.0'
     id 'org.podval.tools.scalajs'      version '0.4.15'
     id 'com.google.cloud.tools.jib'    version '3.4.4'
-    id 'org.podval.tools.cloudrun'     version '0.4.0'
+    id 'org.podval.tools.cloudrun'     version '0.4.1'
     id 'com.gradle.plugin-publish'     version '1.2.1'
   }
 }
 
-final String scalaVersion      = '3.6.2'
+final String scalaVersion      = '3.6.3'
 final String scalaVersionMajor = '3'
 
 final String zioVersion        = '2.1.14'

--- a/util/src/main/scala/org/opentorah/build/Gradle.scala
+++ b/util/src/main/scala/org/opentorah/build/Gradle.scala
@@ -2,64 +2,31 @@ package org.opentorah.build
 
 import org.gradle.api.{Project, Task}
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.provider.{ListProperty, MapProperty, Property}
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.{SourceSet, TaskProvider}
 import org.gradle.api.tasks.scala.ScalaCompile
-import org.gradle.internal.classloader.{ClassLoaderVisitor, ClasspathUtil, VisitableURLClassLoader}
-import org.opentorah.util.Files
-import java.io.File
-import java.net.{URL, URLClassLoader}
-import scala.collection.mutable
-import scala.jdk.CollectionConverters.*
+import scala.jdk.CollectionConverters.SetHasAsScala
 
 object Gradle:
 
   extension(project: Project)
-    def findExtension[T](clazz: Class[T]): Option[T] =
-      Option(project.getExtensions.findByType(clazz))
+    def getConfiguration(name: String): Configuration = project
+      .getConfigurations
+      .getByName(name)
 
-    def getExtension[T](clazz: Class[T]): T =
-      project.getExtensions.getByType(clazz)
+    def getSourceSet(name: String): SourceSet = project
+      .getExtensions
+      .getByType(classOf[JavaPluginExtension])
+      .getSourceSets
+      .getByName(name)
 
-    def getConfiguration(name: String): Configuration =
-      project.getConfigurations.getByName(name)
-
-    def getScalaCompile(sourceSet: SourceSet): ScalaCompile =
-      project.getClassesTask(sourceSet).getScalaCompile
-
-    def getScalaCompile(sourceSetName: String): ScalaCompile =
-      project.getScalaCompile(project.getSourceSet(sourceSetName))
-
-    def findSourceSet(name: String): Option[SourceSet] =
-      project.findExtension(classOf[JavaPluginExtension])
-      .map(_.getSourceSets.getByName(name))
-
-    def getSourceSet(name: String): SourceSet =
-      project
-      .getExtension(classOf[JavaPluginExtension])
-      .getSourceSets.getByName(name)
-
-    def findMainSourceSet: Option[SourceSet] =
-      findSourceSet(SourceSet.MAIN_SOURCE_SET_NAME)
-
-    def getMainSourceSet: SourceSet =
-      getSourceSet(SourceSet.MAIN_SOURCE_SET_NAME)
-
-    def findTask(name: String): Option[Task] =
-      Option(project.getTasks.findByName(name))
-
-    def getTask(name: String): Task =
-      project.getTasks.getByName(name)
-
-    def findClassesTask: Option[Task] =
-      project.findMainSourceSet.flatMap(sourceSet => project.findTask(sourceSet.getClassesTaskName))
-
-    def getClassesTask(sourceSet: SourceSet): Task = project.getTask(sourceSet.getClassesTaskName)
-
-  extension(classesTask: Task)
-    def getScalaCompile: ScalaCompile = classesTask
+    def getClassesTask(sourceSet: SourceSet): Task = project
+      .getTasks
+      .getByName(sourceSet.getClassesTaskName)
+    
+    def getScalaCompile(sourceSet: SourceSet): ScalaCompile = project
+      .getClassesTask(sourceSet)
       .getDependsOn
       .asScala
       .find(classOf[TaskProvider[ScalaCompile]].isInstance)
@@ -71,57 +38,6 @@ object Gradle:
     def toOption: Option[T] =
       if !property.isPresent then None else Some(property.get)
 
-    def getOrElse(default: => T): T =
-      if !property.isPresent then default else property.get
-
   extension[T](property: Property[String])
     def byName(default: => T, all: List[T]): T =
       if !property.isPresent then default else all.find(_.toString == property.get).get
-
-  extension[T](property: ListProperty[T])
-    def toList: List[T] =
-      property.get.asScala.toList
-
-  extension(property: MapProperty[String, String])
-    def toMap: Map[String, String] =
-      property.get.asScala.toMap
-
-  def addToClassPath(obj: AnyRef, files: Iterable[File]): ClassLoader =
-    val result: ClassLoader = obj.getClass.getClassLoader
-
-    val urls: Iterable[URL] = files.map(_.toURI.toURL)
-
-    result match
-      case visitable: VisitableURLClassLoader =>
-        for url <- urls do visitable.addURL(url)
-      case classLoader =>
-        ClasspathUtil.addUrl(
-          classLoader.asInstanceOf[URLClassLoader],
-          urls.asJava
-        )
-
-    result
-  
-  def findOnClassPath(obj: AnyRef, name: String): URL =
-    var result: Option[URL] = None
-
-    val visitor: ClassLoaderVisitor = new ClassLoaderVisitor:
-      override def visitClassPath(classPath: Array[URL]): Unit = classPath
-        .find(_.getPath.contains(name))
-        .foreach((url: URL) => result = Some(url))
-
-    visitor.visit(obj.getClass.getClassLoader)
-
-    result.getOrElse(throw IllegalArgumentException(s"Did not find artifact $name"))
-
-  def collectClassPath(classLoader: ClassLoader): Seq[File] =
-    val result: mutable.ArrayBuffer[File] = mutable.ArrayBuffer.empty[File]
-    val visitor: ClassLoaderVisitor = new ClassLoaderVisitor:
-      override def visitClassPath(classPath: Array[URL]): Unit =
-        for
-          url <- classPath
-          if url.getProtocol == "file"
-        do
-          result += Files.url2file(url)
-    visitor.visit(classLoader)
-    result.toSeq

--- a/util/src/main/scala/org/opentorah/build/GradleBuildContext.scala
+++ b/util/src/main/scala/org/opentorah/build/GradleBuildContext.scala
@@ -8,8 +8,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.SourceSet
 import org.gradle.process.{ExecOperations, JavaExecSpec}
 import java.io.File
-import Gradle.getMainSourceSet
-import scala.jdk.CollectionConverters.*
+import Gradle.getSourceSet
 
 final class GradleBuildContext(project: Project, execOperations: ExecOperations)
   extends GradleBuildContextCore(
@@ -82,7 +81,7 @@ final class GradleBuildContext(project: Project, execOperations: ExecOperations)
     info(s"Running $mainClass(${args.mkString(", ")})")
 
     execOperations.javaexec((exec: JavaExecSpec) =>
-      exec.setClasspath(project.getMainSourceSet.getRuntimeClasspath)
+      exec.setClasspath(project.getSourceSet(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath)
       exec.getMainClass.set(mainClass)
       exec.args(args*)
       ()

--- a/util/src/main/scala/org/opentorah/build/GradleClassPath.scala
+++ b/util/src/main/scala/org/opentorah/build/GradleClassPath.scala
@@ -1,0 +1,46 @@
+package org.opentorah.build
+
+import org.gradle.internal.classloader.{ClassLoaderVisitor, ClasspathUtil, VisitableURLClassLoader}
+import org.opentorah.util.Files
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.IterableHasAsJava
+import java.io.File
+import java.net.{URL, URLClassLoader}
+
+object GradleClassPath:
+  def addTo(obj: AnyRef, files: Iterable[File]): ClassLoader =
+    val result: ClassLoader = obj.getClass.getClassLoader
+    val urls: Iterable[URL] = files.map(_.toURI.toURL)
+
+    result match
+      case visitable: VisitableURLClassLoader =>
+        for url: URL <- urls do visitable.addURL(url)
+      case classLoader =>
+        ClasspathUtil.addUrl(
+          classLoader.asInstanceOf[URLClassLoader],
+          urls.asJava
+        )
+
+    result
+
+  def findOn(obj: AnyRef, name: String): URL =
+    var result: Option[URL] = None
+    val visitor: ClassLoaderVisitor = new ClassLoaderVisitor:
+      override def visitClassPath(classPath: Array[URL]): Unit = classPath
+        .find(_.getPath.contains(name))
+        .foreach((url: URL) => result = Some(url))
+
+    visitor.visit(obj.getClass.getClassLoader)
+    result.getOrElse(throw IllegalArgumentException(s"Did not find artifact $name"))
+
+  def collect(obj: AnyRef): Seq[File] =
+    val result: mutable.ArrayBuffer[File] = mutable.ArrayBuffer.empty[File]
+    val visitor: ClassLoaderVisitor = new ClassLoaderVisitor:
+      override def visitClassPath(classPath: Array[URL]): Unit =
+        for
+          url: URL <- classPath
+          if url.getProtocol == "file"
+        do
+          result += Files.url2file(url)
+    visitor.visit(obj.getClass.getClassLoader)
+    result.toSeq

--- a/util/src/main/scala/org/opentorah/build/ScalaLibrary.scala
+++ b/util/src/main/scala/org/opentorah/build/ScalaLibrary.scala
@@ -37,7 +37,7 @@ object ScalaLibrary:
 
   object Scala2 extends Scala("scala-library"):
     override def versionMajor: Int = 2
-    val versionDefault13: Version = Version("2.13.15")
+    val versionDefault13: Version = Version("2.13.16")
     val versionDefault12: Version = Version("2.12.20")
 
     override def getScalaVersion(library: ScalaLibrary): Version =
@@ -45,7 +45,7 @@ object ScalaLibrary:
 
   object Scala3 extends Scala(artifact = "scala3-library_3"):
     override def versionMajor: Int = 3
-    val versionDefault: Version = Version("3.6.2")
+    val versionDefault: Version = Version("3.6.3")
 
     override def getScalaVersion(library: ScalaLibrary): Version = library.scala3.get.version
 

--- a/util/src/main/scala/org/opentorah/build/TaskWithSourceSet.scala
+++ b/util/src/main/scala/org/opentorah/build/TaskWithSourceSet.scala
@@ -1,0 +1,13 @@
+package org.opentorah.build
+
+import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.{Classpath, SourceSet}
+import org.opentorah.build.Gradle.*
+
+trait TaskWithSourceSet extends Task:
+  protected final def sourceSet: SourceSet = getProject.getSourceSet(sourceSetName)
+
+  protected def sourceSetName: String
+
+  @Classpath final def getRuntimeClassPath: FileCollection = sourceSet.getRuntimeClasspath

--- a/util/src/main/scala/org/opentorah/files/Copy.scala
+++ b/util/src/main/scala/org/opentorah/files/Copy.scala
@@ -4,7 +4,7 @@ import org.opentorah.util.Files
 import java.io.File
 
 // This is a replacement for Gradle-supplied Ant functionality for copying a bunch of files
-// with or without substitutions. I need this since I want DocBook functionality to be usable
+// with or without substitutions. I need this since I wanted DocBook functionality to be usable
 // outside of Gradle.
 // Also, black-boxiness of the Ant stuff with its `"tokens" => ...` was just too much; good riddance!
 private class Copy(substitutions: Map[String, String]):

--- a/util/src/main/scala/org/opentorah/node/NodeDependency.scala
+++ b/util/src/main/scala/org/opentorah/node/NodeDependency.scala
@@ -8,7 +8,8 @@ import java.nio.file.{Files, Path, Paths}
 
 // Heavily inspired by (read: copied and reworked from :)) https://github.com/srs/gradle-node-plugin by srs.
 // That plugin is not used directly because its tasks are not reusable unless the plugin is applied to the project,
-// and I do not want to apply Node plugin to every project that uses DocBook, for instance.
+// and I do not want to apply Node plugin to every project that uses my ScalaJS Gradle plugin, for instance
+// (https://github.com/dubinsky/scalajs-gradle).
 // Also, I want to be able to run npm from within my code without creating tasks.
 // Also, I would like to be able to use Node available via GraalVM's polyglot support.
 // My simplified Node support is under 300 lines.

--- a/util/src/main/scala/org/opentorah/util/Files.scala
+++ b/util/src/main/scala/org/opentorah/util/Files.scala
@@ -58,17 +58,17 @@ object Files:
 
   def string2url(string: String): URL = URI.create(string).toURL
 
-  def subdirectory(url: URL, subdirectoryName: String): URL = URL(url, subdirectoryName + "/")
+  def subdirectory(url: URL, subdirectoryName: String): URL = subUrl(url, subdirectoryName + "/")
 
-  def fileInDirectory(url: URL, fileName: String): URL = URL(url, fileName)
+  def fileInDirectory(url: URL, fileName: String): URL = subUrl(url, fileName)
 
-  def pathUnder(url: URL, path: String): URL = URL(url, if path.startsWith("/") then path.drop(1) else path)
+  def pathUnder(url: URL, path: String): URL = subUrl(url, if path.startsWith("/") then path.drop(1) else path)
+
+  def subUrl(base: Option[URL], url: String): URL = base.fold(URI(url).toURL)(subUrl(_, url))
+
+  private def subUrl(base: URL, url: String): URL = base.toURI.resolve(url).toURL
 
   //def getParent(url: URL): URL = new URL(url, "..")
-
-  def subUrl(base: Option[URL], url: String): URL = base.fold(URL(url))(new URL(_, url))
-  private def subUrl(base: URL, url: String): URL = URL(base, url)
-  def subFile(base: URL, url: String): File = url2file(subUrl(base, url))
 
   def splitUrl(urlRaw: String): Seq[String] =
     val url: String = if urlRaw.isEmpty then "/" else urlRaw


### PR DESCRIPTION
- cleanup: remove more mentions of DocBook
- fix: eliminated invalid call to Project.afterEvaluate() in TaskWithNode
- chore: Java 21
- chore: removed calls to deprecated URL constructors
- chore: Scala 3.6.3/2.13.16
- chore: Gradle cleanup